### PR TITLE
Update and pin Snapcast and librespot versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,37 @@
-FROM rust:1.27 AS librespot
+FROM rust:1.42 AS librespot
 
 RUN apt-get update \
  && apt-get -y install build-essential portaudio19-dev curl unzip \
  && apt-get clean && rm -fR /var/lib/apt/lists
 
-RUN cd /tmp \
- && curl -sLO https://github.com/librespot-org/librespot/archive/master.zip \
- && unzip master.zip \
- && cd librespot-master \
- && cargo build --release \
- && chmod +x /tmp/librespot-master/target/release/librespot
+ARG LIBRESPOT_VERSION=0.1.1
 
-FROM ubuntu
+RUN cd /tmp \
+ && curl -sLO https://github.com/librespot-org/librespot/archive/v0.1.1.zip \
+ && unzip v${LIBRESPOT_VERSION}.zip \
+ && cd librespot-${LIBRESPOT_VERSION} \
+ && cargo build --release \
+ && chmod +x target/release/librespot
+
+FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get -y install curl libportaudio2 libvorbis0a libavahi-client3 libflac8 libvorbisenc2 libvorbisfile3 \
+ && apt-get -y install curl libportaudio2 libvorbis0a libavahi-client3 libflac8 libvorbisenc2 libvorbisfile3 libopus0 \
  && apt-get clean && rm -fR /var/lib/apt/lists
 
 ARG ARCH=amd64
-ARG SNAPCAST_VERSION=0.11.1
+ARG SNAPCAST_VERSION=0.19.0
+ARG LIBRESPOT_VERSION=0.1.1
 
-RUN curl -sL -o /tmp/snapserver.deb https://github.com/badaix/snapcast/releases/download/v${SNAPCAST_VERSION}/snapserver_${SNAPCAST_VERSION}_${ARCH}.deb \
+RUN curl -sL -o /tmp/snapserver.deb https://github.com/badaix/snapcast/releases/download/v${SNAPCAST_VERSION}/snapserver_${SNAPCAST_VERSION}-1_${ARCH}.deb \
  && dpkg -i /tmp/snapserver.deb \
  && rm /tmp/snapserver.deb
 
-COPY --from=librespot /tmp/librespot-master/target/release/librespot /usr/local/bin/
+COPY --from=librespot /tmp/librespot-${LIBRESPOT_VERSION}/target/release/librespot /usr/local/bin/
 
-ENTRYPOINT ["snapserver"]
+ADD init.sh /
+RUN chmod +x /init.sh
+CMD ["/init.sh"]
+
+ENV DEVICE_NAME=Snapcast
 EXPOSE 1704/tcp 1705/tcp

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ _Note: You need a Spotify premium account._
 
 Run it like this (on your PC or ARM-based device):
 
-    docker run -d --name snapserver --net host mazzolino/librespot-snapserver \
-      -s "spotify:///librespot?name=Spotify&username=<my username>&password=<my password>&devicename=Snapcast&bitrate=320"
+    docker run -d --name snapserver --net host -e DEVICE_NAME=Snapcast mazzolino/librespot-snapserver
 
-Now you can connect your snapclient to your host's ip. The receiver should show up in Spotify under the `devicename` given above (e.g. `Snapcast`). Have fun playing music!
+Now you can connect your snapclient to your host's ip. The receiver should show up in Spotify under the `DEVICE_NAME` given above (e.g. `Snapcast`). Have fun playing music!
 
 ## Building the images
 
@@ -31,5 +30,4 @@ Then, on your PC:
 
 Notes:
 
-* Add `SNAPCAST_VERSION=x.xx.x` in order to build a different version of snapcast.
-* Since there are no official librespot releases, It always uses the latest librespot version from git.
+* Add `SNAPCAST_VERSION=x.xx.x` in order to build a different version of snapcast or `LIBRESPOT_VERSION=x.x.x` to build a different version of librespot.

--- a/init.sh
+++ b/init.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-snapserver -d
+snapserver -d --stream.sampleformat=44100:16:2
 librespot -n $DEVICE_NAME -b 320 --backend pipe > /tmp/snapfifo

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+snapserver -d
+librespot -n $DEVICE_NAME -b 320 --backend pipe > /tmp/snapfifo


### PR DESCRIPTION
Thanks for putting this container together! I was having trouble getting it to work, and I found that the snapserver CLI has changed in ways that broke this container. I've pinned all the versions to avoid this problem and reworked the initialization so that it should "just work." I removed the mechanism to specify Spotify username and password as I find it works just fine without them.