### PR TITLE
Fix typo in Makefile breaking non-ARM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 build:
 ifeq ($(ARCH),arm64)
 		docker build -t ${ARCH_IMAGE} --build-arg ARCH=${ARCH} --build-arg SNAPCAST_VERSION=${SNAPCAST_VERSION} --build-arg LIBRESPOT_VERSION=${LIBRESPOT_VERSION} -f Dockerfile.arm64 .
-else ifeq($(ARCH),armhf)
+else ifeq ($(ARCH),armhf)
 		docker build -t ${ARCH_IMAGE} --build-arg ARCH=${ARCH} --build-arg SNAPCAST_VERSION=${SNAPCAST_VERSION} --build-arg LIBRESPOT_VERSION=${LIBRESPOT_VERSION} -f Dockerfile.armhf .
 else
 		docker build -t ${ARCH_IMAGE} --build-arg ARCH=${ARCH} --build-arg SNAPCAST_VERSION=${SNAPCAST_VERSION} --build-arg LIBRESPOT_VERSION=${LIBRESPOT_VERSION} .


### PR DESCRIPTION
A space is needed between `ifeq` and the condition. Without it, make emitted the warning: `Makefile:27: extraneous text after 'else' directive`

Due to this, make ignored the condition, and the branch was treated as a simple `else` statement, always executing even when `ARCH` was *not* `armhf`. With this fix the warning is gone and the correct commands are executed on non-ARM platforms.