### PR TITLE
Use alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,10 @@
-FROM rust:1.62-bullseye AS librespot
+FROM alpine:3.17.1
 
-RUN apt-get update \
- && apt-get -y install build-essential portaudio19-dev curl \
- && apt-get clean && rm -fR /var/lib/apt/lists
+ARG LIBRESPOT_VERSION=0.4.2-r1
+ARG SNAPCAST_VERSION=0.26.0-r3
 
-ARG LIBRESPOT_VERSION=0.4.2
-
-COPY ./install-librespot.sh /tmp/
-RUN --mount=type=tmpfs,size=512M,target=/usr/local/cargo/registry/index /tmp/install-librespot.sh
-
-###
-
-FROM debian:bullseye
-
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >/etc/apt/sources.list.d/bullseye-backports.list
-
-RUN apt-get update \
- && apt-get -y install snapserver/bullseye-backports \
- && apt-get clean && rm -fR /var/lib/apt/lists
-
-COPY --from=librespot /usr/local/cargo/bin/librespot /usr/local/bin/
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories
+RUN apk add --no-cache bash snapcast=${SNAPCAST_VERSION} librespot=${LIBRESPOT_VERSION} sed
 
 COPY run.sh /
 CMD ["/run.sh"]

--- a/install-librespot.sh
+++ b/install-librespot.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-exec cargo install librespot --version "${LIBRESPOT_VERSION}"

--- a/run.sh
+++ b/run.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-# Change snapserver source to Spotify only if the configuration file is writable
-# This allows bind-mounting a custom configuration file (must use "ro" mode)
-if [ -w /etc/snapserver.conf ]; then
+# On alpine the snapserver.conf is located at /usr/etc/snapserver.conf
+# This allows bind-mounting a custom configuration file to /etc/snapserver.conf
+
+if [ -e /etc/snapserver.conf ]; then
+  # If a custom configuration exists, symlink it
+  ln -sf /etc/snapserver.conf  /usr/etc/snapserver.conf
+else
+  # Change snapserver source to Spotify only if no custom configuration is mounted
   credentials=""
   if [[ -n "${USERNAME:-}" ]] && [[ -n "${PASSWORD:-}" ]]; then
     credentials="\&username=$USERNAME\&password=$PASSWORD"
   fi
 
-  sed -i "s,^source = .*,source = librespot:///librespot?name=Spotify\&devicename=$DEVICE_NAME\&bitrate=320\&volume=100$credentials," /etc/snapserver.conf
+  sed -i "s,^source = .*,source = librespot:///librespot?name=Spotify\&devicename=$DEVICE_NAME\&bitrate=320\&volume=100$credentials," /usr/etc/snapserver.conf
 fi
 
-exec snapserver
+exec snapserver -c /usr/etc/snapserver.conf


### PR DESCRIPTION
Instead of using Debian as a base image, use Alpine. This reduces the size of the final image from ~250MB to ~25MB. The current Alpine `edge` branch has packages for the latest release of `snapcast` and `librespot`. This also removes the need for manually compiling `librespot` and a multi-stage built-process.

Side note: on Alpine, `snapcast` is installed in `/usr` so I had to modify the `run.sh` script as well. 